### PR TITLE
Add --list option, and prompt user to open an issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "minimist": "^0.1.0",
     "mkdirp": "^0.5.0",
     "request": "^2.36.0",
-    "run-parallel": "^1.0.0"
+    "run-parallel": "^1.0.0",
+    "prompt": "^0.2.13"
   },
   "keywords": [
     "GitHub",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ var fs = require('fs')
 var runParallel = require('run-parallel')
 var writemarkdown = require('./writemarkdown.js')
 var writehtml = require('./writehtml.js')
+var listofissues = require('./listofissues.js')
 
 var base = 'https://api.github.com'
 var headers = {"user-agent": "offline-issues module"}
@@ -15,6 +16,9 @@ module.exports = function (token, options, cb) {
   headers["Authorization"] = 'token ' + token.token
   if (options._.length === 0 && options.html) {
     return writehtml(options, cb)
+  }
+  if (options._.length === 0 && options.list) {
+    return listofissues(cb)
   }
   if (options._.length === 0) return cb(null, "No repository given.")
   parseRepo(options, cb)

--- a/src/listofissues.js
+++ b/src/listofissues.js
@@ -1,0 +1,34 @@
+var fs = require('fs')
+var prompt = require('prompt')
+var path = 'md/'
+var spawn = require('child_process').spawn
+
+module.exports = function listofissues(cb) {
+  fs.readdir(path, function(err, files) {
+    var num = files.length
+    var list = files.map(function(name, i) {
+      return '  ' + (i + 1) + '. ' + name.replace(/-(\d+)\.\w+$/,'#$1')
+    }).join('\n')
+
+    cb(null, '\nYou have these issues:\n' + list + '\n')
+
+    prompt.start()
+    prompt.message = ''
+    prompt.delimiter = ''
+
+    prompt.get({
+      name: 'number',
+      description: 'Which issue do you want to open? [1-' + num + ']',
+      message: 'Must be a number and <=' + num,
+      conform: function(n) {
+        return n <= num && n.match(/^\d+$/)
+      }
+    }, function (err, result) {
+      if(result && result.number) {
+        var file = './html/' + files[result.number-1].split(/.md/)[0] + '.html'
+        cb(null, 'Opening ' + file)
+        spawn('open', [file])
+      }
+    })
+  })
+}


### PR DESCRIPTION
Hi @jlord how is this.

```
$ offline-issues --list

You have these issues:
  1. github-github#1
  2. github-github#2
  3. github-github#3
  4. github-github#4
  5. muan-emoji#1
  6. muan-github-gmail#1

Which issue do you want to open? [1-6] sup
error:   Invalid input for Which issue do you want to open? [1-6]
error:   Must be a number and <=6
Which issue do you want to open? [1-6] 3
Opening ./html/github-github-3.html
```

I really want issue titles though.
