### PR TITLE
Replace option parser with yargs to show a help message easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ $ offline-issues jlord/offline-issues muan/github-gmail#4
 
 The files are written to whichever directory you are currently in. You will see a `md` and `html` folder added, each of with contains the issues you requested.
 
+## Options
+
+To just generate HTML files from existing offline cache:
+
+```bash
+$ offline-issues -h
+$ offline-issues --html
+```
+
+To skip generating static files for HTML:
+
+```bash
+$ offline-issues -S USER/REPO
+$ offline-issues --no-static USER/REPO
+```
+
+
 ## Build / Develop Locally
 
 - Clone this repository: `git clone https://github.com/jlord/offline-issues.git`

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "ghauth": "^0.3.1",
     "handlebars": "^2.0.0-alpha.4",
     "marked": "^0.3.2",
-    "minimist": "^0.1.0",
     "mkdirp": "^0.5.0",
     "request": "^2.36.0",
-    "run-parallel": "^1.0.0"
+    "run-parallel": "^1.0.0",
+    "yargs": "^3.29.0"
   },
   "keywords": [
     "GitHub",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,10 +1,22 @@
 #!/usr/bin/env node
 
 var ghauth = require('ghauth')
-var minimist = require('minimist')
 var getIssues = require('./index.js')
 
-var options = minimist(process.argv.slice(2))
+var options = require('yargs')
+  .usage('Usage: $0 [options] [repository ...]')
+  .option('html', {
+    alias: 'h',
+    describe: 'If no repository given, generate HTML from existing offline cache',
+    boolean: true
+  })
+  .option('no-static', {
+    alias: 'S',
+    describe: "Don't generate static files for HTML format",
+    boolean: true
+  })
+  .help('help')
+  .argv
 
 var ghAuthOptions = {
  // ~/.config/[configName].json will store the token

--- a/src/writehtml.js
+++ b/src/writehtml.js
@@ -22,7 +22,7 @@ module.exports = function writehtml(options, cb) {
     if (err) return cb(err, "Error writing HTML directory.")
   })
 
-  if (!options.nostatic) {
+  if (!options.noStatic) {
     var from = path.resolve(__dirname , ".." , 'static')
     cpr(from, './html', function(err, files) {
       if (err) return cb(err, "Error copying directory.")


### PR DESCRIPTION
Aim to add ```--help``` option to show a help message like below:

```
$ offline-issues --help
Usage: offline-issues [options] [repository ...]

Options:
  --html, -h       If no repository given, generate HTML from existing offline
                   cache                                               [boolean]
  --no-static, -S  Don't generate static files for HTML format         [boolean]
  --help           Show help                                           [boolean]
```

I guessed behavior of options which are already implemented and created this PR. Please let me know if I misunderstand your options, I'll fix statements above.