### PR TITLE
Check if issue body is null 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ fullcommentdata.json
 fullissuedata.json
 myissuedata.json
 .DS_Store
+html
+md

--- a/src/writehtml.js
+++ b/src/writehtml.js
@@ -55,7 +55,8 @@ function repoDetails(issue) {
 // we should parse them into HTML
 // before putting them in the template
 function parseBody(issue) {
-  issue.body = marked(issue.body)
+  if (issue.body === null) issue.body = ''
+  else issue.body = marked(issue.body)
   issue.comments = issue.comments.map(function(issue) {
     issue.body = marked(issue.body)
     return issue


### PR DESCRIPTION
This just checks to make sure the issue body is not `null` before trying to convert it from Markdown to HTML which was previously throwing an error. 

Also, people, always fill out issue bodies, please! It's so nice 🙏 

Closes #21 