### PR TITLE
Fix cpr

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "cpr": "^0.2.0",
+    "cpr": "^1.1.1",
     "ghauth": "^0.3.1",
     "handlebars": "^2.0.0-alpha.4",
     "marked": "^0.3.2",

--- a/src/writehtml.js
+++ b/src/writehtml.js
@@ -24,8 +24,9 @@ module.exports = function writehtml(options, cb) {
 
   if (!options.noStatic) {
     var from = path.resolve(__dirname , ".." , 'static')
-    cpr(from, './html', function(err, files) {
+    cpr(from, './html', { overwrite: true }, function(err, files) {
       if (err) return cb(err, "Error copying directory.")
+      // TODO this may finish after making the HTML files does
     })
   }
 


### PR DESCRIPTION
There was an error that I think comes from `cpr` when you run `offline-issues` twice in the same directory. 

I got the same error as #29 when testing things on Ubuntu and traced it down to needing to overwrite files with `cpr`.