### PR TITLE
Index HTML page

### DIFF
--- a/src/templates/html.hbs
+++ b/src/templates/html.hbs
@@ -11,6 +11,9 @@
     <div class="container">
       <header>
         <p>
+          <a href="index.html">Back to index</a>
+        </p>
+        <p>
           <span class="badge {{state}}">{{state}}</span>
           <span class="url">{{quicklink}}</span>
         </p>

--- a/src/templates/index.hbs
+++ b/src/templates/index.hbs
@@ -5,25 +5,29 @@
     <link rel="stylesheet" type="text/css" href="css/style.css">
     <script type="text/javascript" src="lib/jquery.js"></script>
     <script type="text/javascript" src="lib/jquery.emoji.js"></script>
-    <title>{{title}}</title>
+    <title>Offline Issues</title>
   </head>
   <body>
     <div class="container">
-      <header>
-        <h1>{{title}}</h1>
-      </header>
-      <div class="issues">
-        {{#issues}}
-        <div class="issue">
-          <a href="{{offlineUrl}}.html">
-            <h2>{{title}}</h2>
-          </a>
-          <span class="badge {{state}}">{{state}}</span>
-          <a class="person" href="https://github.com/{{created_by}}">{{created_by}}</a>
-          <time>{{created_at}}</time>
+      {{#repositories}}
+      <div class="repository">
+        <header>
+          <h1>{{name}}</h1>
+        </header>
+        <div class="issues">
+          {{#issues}}
+          <div class="issue">
+            <a href="{{offlineUrl}}.html">
+              <h2>{{title}}</h2>
+            </a>
+            <span class="badge {{state}}">{{state}}</span>
+            <a class="person" href="https://github.com/{{created_by}}">{{created_by}}</a>
+            <time>{{created_at}}</time>
+          </div>
+          {{/issues}}
         </div>
-        {{/issues}}
       </div>
+      {{/repositories}}
     </div>
   </body>
 </html>

--- a/src/templates/index.hbs
+++ b/src/templates/index.hbs
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" type="text/css" href="css/style.css">
+    <script type="text/javascript" src="lib/jquery.js"></script>
+    <script type="text/javascript" src="lib/jquery.emoji.js"></script>
+    <title>{{title}}</title>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>{{title}}</h1>
+      </header>
+      <div class="issues">
+        {{#issues}}
+        <div class="issue">
+          <a href="{{offlineUrl}}.html">
+            <h2>{{title}}</h2>
+          </a>
+          <span class="badge {{state}}">{{state}}</span>
+          <a class="person" href="https://github.com/{{created_by}}">{{created_by}}</a>
+          <time>{{created_at}}</time>
+        </div>
+        {{/issues}}
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/writehtml.js
+++ b/src/writehtml.js
@@ -70,7 +70,7 @@ function writeIndex (issues, cb) {
 
 function repoName (issues) {
   var a = issues[0].url.split('/')
-  var name = a[3] + '-' + a[4]
+  var name = a[3] + '/' + a[4]
   return name
 }
 

--- a/src/writehtml.js
+++ b/src/writehtml.js
@@ -32,6 +32,13 @@ module.exports = function writehtml (options, cb) {
 
   var issues = fs.readFileSync('comments.json')
   issues = JSON.parse(issues)
+
+  writeIssues(issues, cb)
+  writeIndex(issues, cb)
+  cb(null, 'Wrote html files.')
+}
+
+function writeIssues (issues, cb) {
   issues.forEach(function (issue) {
     issue = parseBody(issue)
     var filename = repoDetails(issue.url)
@@ -39,10 +46,32 @@ module.exports = function writehtml (options, cb) {
     var template = handlebars.compile(source.toString())
     var result = template(issue)
     fs.writeFile('html/' + filename + '.html', result, function (err) {
-      if (err) return cb(err, 'Error writing HTML file.')
+      if (err) return cb(err, 'Error writing HTML issue file.')
     })
   })
-  cb(null, 'Wrote html files.')
+}
+
+function writeIndex (issues, cb) {
+  var source = fs.readFileSync(path.join(__dirname, '/templates/index.hbs'))
+  var template = handlebars.compile(source.toString())
+
+  issues.forEach(function (issue) {
+    issue.offlineUrl = repoDetails(issue.url)
+  })
+
+  var result = template({
+    issues: issues,
+    title: repoName(issues)
+  })
+  fs.writeFile('html/index.html', result, function (err) {
+    if (err) return cb(err, 'Error writing HTML index file.')
+  })
+}
+
+function repoName (issues) {
+  var a = issues[0].url.split('/')
+  var name = a[3] + '-' + a[4]
+  return name
 }
 
 function repoDetails (issue) {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -86,15 +86,21 @@ time {
 .badge.closed { background: #c00; }
 .badge.open { background: #5c5; }
 
+.repositories {}
+.repository {
+  margin-bottom: 60px;
+}
+.repository:last-child {
+  margin-bottom: 0;
+}
+
 .issues {
   margin-top: 40px;
 }
-
 .issue {
   border-bottom: 1px solid #e0e0e0;
   padding-bottom: 20px;
 }
-
 .issue:last-child {
   border-bottom: none;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -85,3 +85,16 @@ time {
 
 .badge.closed { background: #c00; }
 .badge.open { background: #5c5; }
+
+.issues {
+  margin-top: 40px;
+}
+
+.issue {
+  border-bottom: 1px solid #e0e0e0;
+  padding-bottom: 20px;
+}
+
+.issue:last-child {
+  border-bottom: none;
+}


### PR DESCRIPTION
This adds an index page to the HTML output and links on each issue to return to the index page. Multiple repositories work just fine, though with few frills.

This includes some pretty significant changes to the `writehtml.js` file to parse the comments in a more robust manner. I think the added processing time will be offset by not running the `writeIssues` loop for duplicated comments.

Let me know what you think!

<img width="771" alt="screen shot 2016-10-26 at 10 42 39 am" src="https://cloud.githubusercontent.com/assets/2095463/19737667/280ef1b8-9b69-11e6-8e8d-e8cae8f8a8ff.png">

References: #3, #18 
