### PR TITLE
Onefile output

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -25,6 +25,10 @@ var options = require('yargs')
     choices: ['open', 'closed', 'all'],
     default: 'open'
   })
+  .option("onefile", {
+    describe: "Bundle issue into a single file",
+    boolean: false
+  })
   .help('help')
   .argv
 

--- a/src/writemarkdown.js
+++ b/src/writemarkdown.js
@@ -17,22 +17,46 @@ module.exports = function writemarkdown (options, cb) {
 
   var issues = fs.readFileSync('comments.json')
   issues = JSON.parse(issues)
-  issues.forEach(function (issue) {
-    var filename = repoDetails(issue.url)
-    var source = fs.readFileSync(path.join(__dirname, '/templates/markdown.hbs'))
-    var template = handlebars.compile(source.toString())
-    var result = template(issue)
-
-    fs.writeFile(dest + '/' + filename + '.md', result, function (err) {
-      if (err) return cb(err, 'Error writing md file.')
-    })
-
-  })
+  writeIssueToFile(dest, issues, options.onefile)
   cb(null, 'Wrote markdown files.')
+}
+
+function writeIssueToFile(dest, issues, onefile = false) {
+  if (issues.length > 0) {
+    if (onefile) {
+      var filename = repoOwner(issues[0].url)
+      var source = fs.readFileSync(path.join(__dirname, '/templates/markdown.hbs'))
+      var template = handlebars.compile(source.toString())
+      var results = ''
+      issues.forEach(function (issue) {
+        var result = template(issue)
+        results += result + '\n'
+      })
+      fs.writeFile(dest + '/' + filename + '.md', results, function (err) {
+        if (err) return cb(err, 'Error writing md file.')
+      })
+    } else {
+      issues.forEach(function (issue) {
+        var filename = repoDetails(issue.url)
+        var source = fs.readFileSync(path.join(__dirname, '/templates/markdown.hbs'))
+        var template = handlebars.compile(source.toString())
+        var result = template(issue)
+
+        fs.writeFile(dest + '/' + filename + '.md', result, function (err) {
+          if (err) return cb(err, 'Error writing md file.')
+        })
+      })
+    }
+  }
 }
 
 function repoDetails (issue) {
   var a = issue.split('/')
   var filename = a[3] + '-' + a[4] + '-' + a[6]
   return filename
+}
+
+function repoOwner (issue) {
+  var a = issue.split('/')
+  return a[3] + '-' + a[4]
 }


### PR DESCRIPTION
## Details
add `--onefile` options to output the result into a single file. This will result in the file name to be `org-reponame`  

## Breakdown
- [x] handle 1 file output 